### PR TITLE
move lodash to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "test": "jest && eslint .",
     "test:coverage": "jest --config jestconfig.coverage.json"
   },
+  "dependencies": {
+    "lodash": "^4.17.20"
+  },
   "devDependencies": {
     "@babel/cli": "^7.12.8",
     "@babel/core": "^7.12.9",
@@ -37,7 +40,6 @@
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^26.6.3",
     "jest-matcher-css": "^1.1.0",
-    "lodash": "^4.17.20",
     "postcss": "^8.1.10",
     "prettier": "^2.2.0",
     "tailwindcss": "^2.0.1"


### PR DESCRIPTION
Hello,

When using Yarn 2 and its zero install mode, dependencies need to be properly declared for access to be granted. This module relies on `lodash` but only marks it as a development dependency.

I've moved `lodash` from `devDependencies` to `dependencies`. 